### PR TITLE
Tool details mobile visibility

### DIFF
--- a/src/components/ToolCarousel.tsx
+++ b/src/components/ToolCarousel.tsx
@@ -12,10 +12,14 @@ interface ToolCarouselProps {
 
 const EXIT_DURATION_MS = 180;
 const ENTER_DURATION_MS = 240;
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
 
 export function ToolCarousel({ tools, isSectionOpen = false }: ToolCarouselProps) {
   const [index, setIndex] = useState(0);
-  const [cardExpanded, setCardExpanded] = useState(true);
+  const [cardExpanded, setCardExpanded] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return !window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+  });
   const containerRef = useRef<HTMLDivElement>(null);
   const prevSectionOpenRef = useRef(false);
   const swipeStartRef = useRef<{ x: number; y: number } | null>(null);


### PR DESCRIPTION
Close tool details by default on mobile viewports to improve the UI experience.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b40e1604-40a7-4082-9dca-376d4fe15cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b40e1604-40a7-4082-9dca-376d4fe15cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change gated by viewport size; main risk is minor hydration/behavior differences around initial render on mobile.
> 
> **Overview**
> Tool details in `ToolCarousel` now start **collapsed on mobile viewports** by initializing `cardExpanded` from a `(max-width: 767px)` media query (with an SSR-safe fallback).
> 
> Desktop behavior is unchanged (details start expanded), and existing expand/collapse toggling continues to work via the controlled `expanded`/`onExpandToggle` props passed into `ToolCard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06944633eee01e372060cbbfec5d4a6232f59019. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->