### PR TITLE
Mobile tool hover effect

### DIFF
--- a/src/components/SectionPanel.tsx
+++ b/src/components/SectionPanel.tsx
@@ -40,11 +40,40 @@ export function SectionPanel({
                 ? HOVER_GLOW
                 : undefined;
 
+    const handlePointerEnter = (
+        event: React.PointerEvent<HTMLDivElement>,
+    ) => {
+        if (event.pointerType === 'mouse') {
+            setIsHovered(true);
+        }
+    };
+
+    const handlePointerLeave = (
+        event: React.PointerEvent<HTMLDivElement>,
+    ) => {
+        if (event.pointerType === 'mouse') {
+            setIsHovered(false);
+        }
+    };
+
+    const handlePointerDown = (
+        event: React.PointerEvent<HTMLDivElement>,
+    ) => {
+        if (event.pointerType !== 'mouse') {
+            setIsHovered(true);
+        }
+    };
+
+    const clearTouchHover = (event: React.PointerEvent<HTMLDivElement>) => {
+        if (event.pointerType !== 'mouse') {
+            setIsHovered(false);
+        }
+    };
+
     return (
         <div
             className={clsx(
                 'border transition-all duration-[350ms] overflow-hidden ease-out',
-                'hover:-translate-y-1 hover:scale-[1.008]',
                 !hideHeader && isOpen && 'shadow-lg',
             )}
             style={{
@@ -61,9 +90,15 @@ export function SectionPanel({
                         ? 'var(--border-muted)'
                         : 'var(--border-subtle)',
                 boxShadow,
+                transform: isHovered
+                    ? 'translate3d(0, -0.25rem, 0) scale(1.008)'
+                    : undefined,
             }}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
+            onPointerEnter={handlePointerEnter}
+            onPointerLeave={handlePointerLeave}
+            onPointerDown={handlePointerDown}
+            onPointerUp={clearTouchHover}
+            onPointerCancel={clearTouchHover}
         >
             {!hideHeader && (
                 <button


### PR DESCRIPTION
Add the desktop hover/motion effect to mobile for pre-click touch interactions.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-65f935c9-f5fa-4d85-9449-e6d4bcc2bff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65f935c9-f5fa-4d85-9449-e6d4bcc2bff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only behavior change limited to `SectionPanel`, but pointer event handling can subtly affect hover state on some devices/browsers.
> 
> **Overview**
> Adds a mobile-friendly hover/motion effect to `SectionPanel` by switching from `onMouseEnter/Leave` to pointer-event handlers.
> 
> Hover state is now set on non-mouse `pointerdown` and cleared on `pointerup/cancel`, and the previous Tailwind hover transform is replaced with an inline `transform` driven by `isHovered` so touch can trigger the same lift/scale animation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea49bb33afb059c213dc737414101131f3dd1d81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->