### PR TITLE
Light mode tool white effect

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@
     --shadow-panel: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
     --dot-active: #d97706;
     --dot-inactive: rgba(255, 255, 255, 0.35);
+    --tool-card-slide-opacity: 0.2;
     color-scheme: dark;
 }
 
@@ -53,6 +54,7 @@
     --shadow-panel: 0 25px 50px -12px rgba(50, 40, 30, 0.15);
     --dot-active: #b45309;
     --dot-inactive: rgba(60, 50, 40, 0.35);
+    --tool-card-slide-opacity: 1;
     --glass-blur: 20px;
     --glass-edge: rgba(60, 50, 40, 0.06);
     color-scheme: light;
@@ -102,7 +104,7 @@ body,
     }
     to {
         transform: translate3d(-24%, 0, 0);
-        opacity: 0.2;
+        opacity: var(--tool-card-slide-opacity);
     }
 }
 
@@ -113,14 +115,14 @@ body,
     }
     to {
         transform: translate3d(24%, 0, 0);
-        opacity: 0.2;
+        opacity: var(--tool-card-slide-opacity);
     }
 }
 
 @keyframes tool-card-slide-in-right {
     from {
         transform: translate3d(24%, 0, 0);
-        opacity: 0.2;
+        opacity: var(--tool-card-slide-opacity);
     }
     to {
         transform: translateX(0);
@@ -131,7 +133,7 @@ body,
 @keyframes tool-card-slide-in-left {
     from {
         transform: translate3d(-24%, 0, 0);
-        opacity: 0.2;
+        opacity: var(--tool-card-slide-opacity);
     }
     to {
         transform: translateX(0);


### PR DESCRIPTION
Fixes light mode tool icons showing a white "rest" state before turning orange.

The light theme was inheriting a low opacity transition, causing a pale/white look before settling to orange accents. This PR makes the tool carousel slide opacity theme-aware, setting it to `1` for light mode to prevent the white fade, while maintaining `0.2` for dark mode.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e7f8b80f-07c4-4165-9167-e8f87ab45490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7f8b80f-07c4-4165-9167-e8f87ab45490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change that tweaks animation opacity values; impact is limited to the tool carousel’s visual transition behavior across themes.
> 
> **Overview**
> Fixes the light-theme “white rest” effect during tool carousel card transitions by making the slide animation opacity theme-aware.
> 
> Adds a new CSS variable `--tool-card-slide-opacity` (set to `0.2` in dark mode and `1` in light mode) and updates the `tool-card-slide-*` keyframes to use it instead of a hardcoded `0.2` opacity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9729c9853fed53a7c71fe7ac71f31758dc7c1d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->