### PR TITLE
Light mode hover colors

### DIFF
--- a/src/components/SectionPanel.tsx
+++ b/src/components/SectionPanel.tsx
@@ -79,15 +79,13 @@ export function SectionPanel({
             style={{
                 backgroundColor: hideHeader
                     ? 'var(--bg-card)'
-                    : isOpen
+                    : isHovered || isOpen
                       ? 'var(--bg-card-hover)'
                       : 'var(--bg-card)',
                 borderColor: hideHeader
                     ? 'var(--border-subtle)'
-                    : isHovered
-                      ? 'var(--border-muted)'
-                      : isOpen
-                        ? 'var(--border-muted)'
+                    : isHovered || isOpen
+                      ? 'var(--accent-muted)'
                         : 'var(--border-subtle)',
                 boxShadow,
                 transform: isHovered
@@ -103,7 +101,13 @@ export function SectionPanel({
             {!hideHeader && (
                 <button
                     onClick={onToggle}
-                    className="w-full flex items-center justify-between gap-4 p-5 md:p-6 max-md:p-4 max-md:gap-3 max-md:touch-manipulation text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]"
+                    className="w-full flex items-center justify-between gap-4 p-5 md:p-6 max-md:p-4 max-md:gap-3 max-md:touch-manipulation text-left transition-colors theme-accent-interaction focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]"
+                    style={{
+                        backgroundColor:
+                            isHovered || isOpen
+                                ? 'var(--accent-soft)'
+                                : 'transparent',
+                    }}
                 >
                     <div className="min-w-0 flex-1">
                         <h2 className="font-display text-lg md:text-xl font-semibold tracking-tight text-[var(--text-primary)] truncate max-md:text-base flex items-center gap-2">

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -66,7 +66,7 @@ export function ToolCard({
 
                 <button
                     onClick={() => setIsExpanded(!isExpanded)}
-                    className="mt-4 max-md:mt-3 flex items-center justify-between gap-2 w-full py-2 rounded-lg text-sm font-medium transition-colors theme-hover-opacity max-md:text-xs max-md:touch-manipulation"
+                    className="mt-4 max-md:mt-3 flex items-center justify-between gap-2 w-full py-2 rounded-lg text-sm font-medium transition-colors theme-hover-opacity theme-accent-interaction max-md:text-xs max-md:touch-manipulation"
                     style={{ color: 'var(--accent)' }}
                 >
                     <span>{isExpanded ? 'Less details' : 'More details'}</span>
@@ -101,7 +101,7 @@ export function ToolCard({
                             href={tool.detailsGuide.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium transition-colors border theme-hover-opacity w-fit"
+                            className="inline-flex items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium transition-colors border theme-hover-opacity theme-accent-interaction w-fit"
                             style={{
                                 backgroundColor: 'var(--accent-soft)',
                                 borderColor: 'var(--accent-muted)',

--- a/src/components/ToolCarousel.tsx
+++ b/src/components/ToolCarousel.tsx
@@ -181,7 +181,7 @@ export function ToolCarousel({ tools, isSectionOpen = false }: ToolCarouselProps
           type="button"
           onClick={goPrev}
           disabled={!hasPrev || isAnimating}
-          className="hidden md:flex shrink-0 w-10 h-10 rounded-xl items-center justify-center border transition-colors theme-hover-opacity disabled:opacity-40 disabled:pointer-events-none"
+          className="hidden md:flex shrink-0 w-10 h-10 rounded-xl items-center justify-center border transition-colors theme-hover-opacity theme-accent-interaction disabled:opacity-40 disabled:pointer-events-none"
           style={navButtonStyle}
           aria-label="Previous tool"
         >
@@ -204,7 +204,7 @@ export function ToolCarousel({ tools, isSectionOpen = false }: ToolCarouselProps
             type="button"
             onClick={goPrev}
             disabled={!hasPrev || isAnimating}
-            className="md:hidden shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border transition-colors theme-hover-opacity disabled:opacity-40 disabled:pointer-events-none touch-manipulation"
+            className="md:hidden shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border transition-colors theme-hover-opacity theme-accent-interaction disabled:opacity-40 disabled:pointer-events-none touch-manipulation"
             style={navButtonStyle}
             aria-label="Previous tool"
           >
@@ -237,7 +237,7 @@ export function ToolCarousel({ tools, isSectionOpen = false }: ToolCarouselProps
             type="button"
             onClick={goNext}
             disabled={!hasNext || isAnimating}
-            className="shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border transition-colors theme-hover-opacity disabled:opacity-40 disabled:pointer-events-none max-md:touch-manipulation"
+            className="shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border transition-colors theme-hover-opacity theme-accent-interaction disabled:opacity-40 disabled:pointer-events-none max-md:touch-manipulation"
             style={navButtonStyle}
             aria-label="Next tool"
           >

--- a/src/index.css
+++ b/src/index.css
@@ -48,8 +48,8 @@
     --text-secondary: #57534e;
     --text-muted: #78716c;
     --accent: #b45309;
-    --accent-muted: rgba(180, 83, 9, 0.22);
-    --accent-soft: rgba(180, 83, 9, 0.14);
+    --accent-muted: rgba(180, 83, 9, 0.3);
+    --accent-soft: rgba(180, 83, 9, 0.22);
     --glow-primary: rgba(217, 119, 6, 0.1);
     --glow-secondary: rgba(180, 83, 9, 0.05);
     --glow-center: rgba(217, 119, 6, 0.04);
@@ -108,6 +108,21 @@ body,
 
 .theme-hover-opacity:hover {
     opacity: var(--interactive-hover-opacity);
+}
+
+/* Keep tool interactions warm/orange in light mode (avoid white flash). */
+.theme-accent-interaction {
+    -webkit-tap-highlight-color: transparent;
+    transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease;
+}
+
+.theme-accent-interaction:hover,
+.theme-accent-interaction:focus-visible,
+.theme-accent-interaction:active {
+    background-color: var(--accent-soft);
+    border-color: var(--accent-muted);
 }
 
 @keyframes tool-card-slide-out-left {


### PR DESCRIPTION
Eliminate white flash on light mode tool hover and open animations to ensure consistent orange accent coloring.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-dbe14eed-2aeb-4f4a-9437-6b4036d1467a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbe14eed-2aeb-4f4a-9437-6b4036d1467a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

