### PR TITLE
Light mode tool colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,17 +39,17 @@
 [data-theme='light'] {
     --bg-base: #ebe0d4;
     --bg-panel: #e2d6c8;
-    --bg-panel-hover: #e0d4c6;
+    --bg-panel-hover: #e6dbcf;
     --bg-card: #dfd2c2;
-    --bg-card-hover: #ddcfbf;
+    --bg-card-hover: #e4d9cc;
     --border-subtle: rgba(70, 55, 45, 0.12);
     --border-muted: rgba(70, 55, 45, 0.2);
     --text-primary: #1c1917;
     --text-secondary: #57534e;
     --text-muted: #78716c;
     --accent: #b45309;
-    --accent-muted: rgba(180, 83, 9, 0.3);
-    --accent-soft: rgba(180, 83, 9, 0.22);
+    --accent-muted: rgba(180, 83, 9, 0.22);
+    --accent-soft: rgba(180, 83, 9, 0.12);
     --glow-primary: rgba(217, 119, 6, 0.1);
     --glow-secondary: rgba(180, 83, 9, 0.05);
     --glow-center: rgba(217, 119, 6, 0.04);


### PR DESCRIPTION
Adjust light mode CSS variables to align tool hover/open/inner card colors with dark mode's subtle interaction hierarchy.

The previous light mode colors for these states were too strong/dark, diverging from the intended visual hierarchy seen in dark mode. This change rebalances the tokens to provide a gentler, elevated tint.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9dc8ddf4-f4c6-4e82-b034-da9e31c793eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9dc8ddf4-f4c6-4e82-b034-da9e31c793eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

