### PR TITLE
Update CODEOWNERS and chat model references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,3 @@
-# CODEOWNERS
-#
-# This file defines the default reviewers/owners for changes in this repo.
-# Update the GitHub handles below to match your actual team.
-
-# Everything in the repo
-* @github-username-here
+# Default owners for the repo
+* @ayomidecole
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Core contributors for the whole repo
-*   @ayomidecole

--- a/api/chat.js
+++ b/api/chat.js
@@ -799,7 +799,7 @@ function buildSystemPrompt(opts) {
   }
   return DEFAULT_SYSTEM_PROMPT;
 }
-function getModelForMode(mode) {
+function getModelForMode() {
   return "gpt-5.2";
 }
 function formatSuggestStackMarkdown(stack) {
@@ -911,7 +911,7 @@ async function handleChatRequest(apiKey, body) {
     return { status: 400, json: { error: "messages array must contain user/assistant messages" } };
   }
   const latestUserMessage = getLatestUserMessage(sanitizedMessages);
-  const model = getModelForMode(body.mode);
+  const model = getModelForMode();
   if (body.mode === "suggest-stack") {
     const tools = getSuggestStackToolList();
     const systemPrompt2 = buildSuggestStackSystemPrompt(tools);

--- a/api/chat.js
+++ b/api/chat.js
@@ -800,7 +800,7 @@ function buildSystemPrompt(opts) {
   return DEFAULT_SYSTEM_PROMPT;
 }
 function getModelForMode(mode) {
-  return mode === "suggest-stack" ? "gpt-4o" : "gpt-4o-mini";
+  return "gpt-5.2";
 }
 function formatSuggestStackMarkdown(stack) {
   const lines = [stack.summary, ""];

--- a/shared/chatPolicy.ts
+++ b/shared/chatPolicy.ts
@@ -264,8 +264,9 @@ export function buildSystemPrompt(opts: {
   return DEFAULT_SYSTEM_PROMPT
 }
 
-export function getModelForMode(mode?: string): string {
-  return mode === 'suggest-stack' ? 'gpt-4o' : 'gpt-4o-mini'
+export function getModelForMode(): string {
+  // Use OpenAI's current flagship chat model for all modes
+  return 'gpt-5.2'
 }
 
 function formatSuggestStackMarkdown(stack: SuggestStackStack): string {

--- a/shared/chatPolicy.ts
+++ b/shared/chatPolicy.ts
@@ -412,7 +412,7 @@ export async function handleChatRequest(
   }
 
   const latestUserMessage = getLatestUserMessage(sanitizedMessages)
-  const model = getModelForMode(body.mode)
+  const model = getModelForMode()
 
   if (body.mode === 'suggest-stack') {
     const tools = getSuggestStackToolList()


### PR DESCRIPTION
- Deleted the old CODEOWNERS file and updated the new one to reflect the current default owner as @ayomidecole.
- Changed the chat model reference in api/chat.js and shared/chatPolicy.ts from "gpt-4o" to "gpt-5.2" for consistency and to utilize the latest model across all modes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ayomidecole/ai-hackathon-guide/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
