### PR TITLE
Update Replit video to agent 4 announcement

### DIFF
--- a/src/content/sections.ts
+++ b/src/content/sections.ts
@@ -135,9 +135,9 @@ export const sections: Section[] = [
                     url: 'https://docs.replit.com/tutorials/effective-prompting',
                 },
                 detailsVideo: {
-                    title: 'Replit agent 4 announcement',
-                    embedUrl: 'https://www.youtube.com/embed/-2xHmkpmCBM',
-                    watchUrl: 'https://youtu.be/-2xHmkpmCBM',
+                    title: 'Watch: Replit walkthrough',
+                    embedUrl: 'https://www.youtube.com/embed/TAXRZyGV1Dw?start=42',
+                    watchUrl: 'https://www.youtube.com/watch?v=TAXRZyGV1Dw&t=42s',
                 },
                 detailsSections: [
                     {
@@ -159,6 +159,33 @@ export const sections: Section[] = [
                         items: [
                             'Use Replit Auth for authentication; validate user input; secure API endpoints with rate limiting.',
                             'Never commit secrets—use the Secrets manager and keep credentials out of version control.',
+                        ],
+                    },
+                ],
+            },
+            {
+                id: 'replit-agent-4-announcement',
+                name: 'Replit agent 4 announcement',
+                tagline: 'Official Replit update video',
+                description:
+                    'Announcement video for Replit Agent 4 with latest updates and product direction.',
+                bullets: [
+                    'Agent 4 feature overview',
+                    'Product announcement',
+                    'Official video update',
+                ],
+                url: 'https://youtu.be/-2xHmkpmCBM',
+                detailsVideo: {
+                    title: 'Replit agent 4 announcement',
+                    embedUrl: 'https://www.youtube.com/embed/-2xHmkpmCBM',
+                    watchUrl: 'https://youtu.be/-2xHmkpmCBM',
+                },
+                detailsSections: [
+                    {
+                        heading: 'What this includes',
+                        items: [
+                            'High-level overview of Replit Agent 4 and how it fits into AI-assisted development workflows.',
+                            'Product announcement details and latest feature direction from Replit.',
                         ],
                     },
                 ],

--- a/src/content/sections.ts
+++ b/src/content/sections.ts
@@ -135,9 +135,9 @@ export const sections: Section[] = [
                     url: 'https://docs.replit.com/tutorials/effective-prompting',
                 },
                 detailsVideo: {
-                    title: 'Watch: Replit walkthrough',
-                    embedUrl: 'https://www.youtube.com/embed/TAXRZyGV1Dw?start=42',
-                    watchUrl: 'https://www.youtube.com/watch?v=TAXRZyGV1Dw&t=42s',
+                    title: 'Replit agent 4 announcement',
+                    embedUrl: 'https://www.youtube.com/embed/-2xHmkpmCBM',
+                    watchUrl: 'https://youtu.be/-2xHmkpmCBM',
                 },
                 detailsSections: [
                     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Keep the original Replit walkthrough video intact.
- Add a **new, separate tool card** for the requested video: **Replit agent 4 announcement**.

## Context

- Related issue / ticket (if any): N/A
- Brief background or motivation: The requested video should be added, not replace the existing Replit walkthrough.

## Changes

- In `src/content/sections.ts` under `Development tools`:
  - Restored `replit.detailsVideo` to original walkthrough values:
    - title: `Watch: Replit walkthrough`
    - embedUrl: `https://www.youtube.com/embed/TAXRZyGV1Dw?start=42`
    - watchUrl: `https://www.youtube.com/watch?v=TAXRZyGV1Dw&t=42s`
  - Added new tool:
    - `id: replit-agent-4-announcement`
    - `name: Replit agent 4 announcement`
    - `url/detailsVideo` pointing to `https://youtu.be/-2xHmkpmCBM`
- User-visible change: both the original Replit walkthrough and the new announcement video now exist as separate entries.

## Testing

- [ ] `npm run build` (if relevant)
- [ ] `npm run lint` (if relevant)
- [x] Manually exercised the main flows affected (content verification in source)

Notes:
- Automated tests were not run in this environment due to missing local test dependency (`vitest: not found`).

## Docs / meta updates

- [ ] Updated documentation if behavior or workflows changed
- [ ] Updated `AGENTS.md` if agent behavior or workflows changed
- [x] Updated `src/content/sections.ts` if tools or sections changed

## Screenshots (if UI changes)

- Before: Replit announcement replaced the existing Replit walkthrough.
- After: Existing Replit walkthrough restored; new Replit announcement card added.

## Additional notes

- Content-only update; no runtime logic changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d818a057-4338-4238-841c-7b598add5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d818a057-4338-4238-841c-7b598add5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

